### PR TITLE
Random empty report with Jasmine and PhantomJS

### DIFF
--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/instrumentation/HtmlUnitBasedScriptInstrumenter.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/instrumentation/HtmlUnitBasedScriptInstrumenter.java
@@ -27,6 +27,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Files;
 import com.google.common.io.InputSupplier;
+import java.util.Collections;
 import net.sourceforge.htmlunit.corejs.javascript.Parser;
 import net.sourceforge.htmlunit.corejs.javascript.ast.AstRoot;
 import org.codehaus.plexus.util.FileUtils;
@@ -51,7 +52,7 @@ public final class HtmlUnitBasedScriptInstrumenter implements ScriptInstrumenter
     private static final Set<URI> writtenToDisk = Sets.newHashSet();
 
     private final Config config;
-    private final List<ScriptData> scriptDataList = Lists.newLinkedList();
+    private final List<ScriptData> scriptDataList = Collections.synchronizedList( Lists.<ScriptData>newLinkedList() );
     private Collection<Pattern> ignorePatterns;
     private File instrumentedFileDirectory;
 


### PR DESCRIPTION
Same pull request as on the official repository:

Hello,

By using saga with Jasmine and PhantomJS, I got empty reports randomly. 
When the report is empty, the console message is:

Error running test http://<ip>:<port>: null

With debug activated, I have a nullPointerException in LinkedList. That's why I think this pull request also fixed the issue #121 
With the fix it seams I can't reproduce the problem anymore.

Can you integrate this pull request and generate a release ?

Thanks in advance
JB
